### PR TITLE
Output error when trying to protect zip files with other files

### DIFF
--- a/src/bin/jscrambler
+++ b/src/bin/jscrambler
@@ -71,6 +71,13 @@ if (globSrc && globSrc.length) {
   for (let i = 0, l = globSrc.length; i < l; ++i) {
     // Calling sync `glob` because async is pointless for the CLI use case
     // (as of now at least)
+
+    // If the user is providing a zip alongside more files
+    if (path.extname(globSrc[i]) === '.zip' && globSrc.length > 1) {
+      console.error('Please either provide a zip file containing all your source files or use the minimatch syntax');
+      process.exit(1);
+    }
+
     const tmpGlob = glob.sync(globSrc[i], {
       dot: true
     });


### PR DESCRIPTION
We're currently allowing users to upload zip files with other files. This will create a zip of the zip and the other files which will result in a failed protection.