### PR TITLE
protectAndDownload: return protectionId

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -292,6 +292,7 @@ export default {
     unzip(download, filesDest || destCallback, stream);
     debug && console.log('Finished unzipping files');
     console.log(protectionId);
+    return protectionId
   },
 
   async downloadSourceMaps (configs, destCallback) {


### PR DESCRIPTION
This ID can be used for subsequent tasks (eg. removing the protection
once downloaded)