### PR TITLE
[CI-757] Support to limit protections returned in getApplication and getApplications queries

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -291,7 +291,7 @@ export default {
     debug && console.log('Unzipping files');
     unzip(download, filesDest || destCallback, stream);
     debug && console.log('Finished unzipping files');
-    console.log(protectionId);
+    debug && console.log(protectionId);
   },
 
   async downloadSourceMaps (configs, destCallback) {
@@ -455,9 +455,9 @@ export default {
     return deferred.promise;
   },
   //
-  async getApplications (client, fragments) {
+  async getApplications (client, fragments, params) {
     const deferred = Q.defer();
-    client.get('/application', getApplications(fragments), responseHandler(deferred));
+    client.get('/application', getApplications(fragments, params), responseHandler(deferred));
     return deferred.promise;
   },
   //

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -291,7 +291,7 @@ export default {
     debug && console.log('Unzipping files');
     unzip(download, filesDest || destCallback, stream);
     debug && console.log('Finished unzipping files');
-    debug && console.log(protectionId);
+    console.log(protectionId);
   },
 
   async downloadSourceMaps (configs, destCallback) {
@@ -413,9 +413,9 @@ export default {
     return deferred.promise;
   },
   //
-  async getApplication (client, applicationId, fragments) {
+  async getApplication (client, applicationId, fragments, params) {
     const deferred = Q.defer();
-    client.get('/application', getApplication(applicationId, fragments), responseHandler(deferred));
+    client.get('/application', getApplication(applicationId, fragments, params), responseHandler(deferred));
     return deferred.promise;
   },
   //

--- a/src/lib/queries.js
+++ b/src/lib/queries.js
@@ -113,17 +113,24 @@ const getApplicationsDefaultFragments = `
   protections,
   parameters
 `;
-
-export function getApplications (fragments = getApplicationsDefaultFragments) {
+/**
+ * Return all applications. You can use the optional params to limit the returned protections
+ * by the version and number of results
+ * @param {fragment} fragments GraphQL fragment
+ * @param {Array} params {{String}protectionsVersion, {Integer} protectionsNumber}
+ */
+export function getApplications (fragments = getApplicationsDefaultFragments, params) {
   return {
     query: `
-      query getApplications {
-        applications {
+      query getApplications($protectionsVersion:String, $protectionsLimit: Int) {
+        applications(protectionsVersion: $protectionsVersion, protectionsLimit: $protectionsLimit) {
           ${fragments}
         }
       }
     `,
-    params: '{}'
+    params: JSON.stringify({
+      ...params
+    })
   };
 }
 

--- a/src/lib/queries.js
+++ b/src/lib/queries.js
@@ -8,18 +8,25 @@ const getApplicationDefaultFragments = `
     extension
   }
 `;
-
-export function getApplication (applicationId, fragments = getApplicationDefaultFragments) {
+/**
+ * Return one application by id.
+ * The options params argument can be used to filter protections by version and limit the number of protections returned.
+ * @param {String} id the application id
+ * @param {fragment} fragments GraphQL fragment
+ * @param {Array} params {{String}protectionsVersion, {Integer} protectionsNumber}
+ */
+export function getApplication (applicationId, fragments = getApplicationDefaultFragments, params) {
   return {
     query: `
-      query getApplication ($applicationId: String!) {
-        application(_id: $applicationId) {
+      query getApplication ($applicationId: String!, $protectionsVersion: String, $protectionsLimit: Int) {
+        application(_id: $applicationId, protectionsVersion: $protectionsVersion, protectionsLimit: $protectionsLimit) {
           ${fragments}
         }
       }
     `,
     params: JSON.stringify({
-      applicationId
+      applicationId,
+      ...params
     })
   };
 }
@@ -114,8 +121,8 @@ const getApplicationsDefaultFragments = `
   parameters
 `;
 /**
- * Return all applications. You can use the optional params to limit the returned protections
- * by the version and number of results
+ * Return all applications.
+ * The options params argument can be used to filter protections by version and limit the number of protections returned.
  * @param {fragment} fragments GraphQL fragment
  * @param {Array} params {{String}protectionsVersion, {Integer} protectionsNumber}
  */


### PR DESCRIPTION
New Features:

getApplication supports 2 new params: "protectionsVersion" and "protectionsLimit".
getApplications supports 2 new params: "protectionsVersion" and "protectionsLimit".

protectionsVersion {String, optional} limit the protections returned to this version
protectionsLimit {Int, optional} limit the returned protections

Small fix:
add debug condition to console.log
