### PR TITLE
use correct schema depending on jscramblerVers…

### DIFF
--- a/src/lib/get-protection-default-fragments.js
+++ b/src/lib/get-protection-default-fragments.js
@@ -1,0 +1,47 @@
+export default {
+  '5.1': {
+    application: `
+      name
+    `,
+    applicationProtection: `
+      _id,
+      state,
+      bail,
+      deprecations,
+      errorMessage,
+      sources {
+        filename,
+        errorMessages {
+          message,
+          line,
+          column,
+          fatal
+        }
+      }
+    `
+  },
+  '5.2': {
+    application: `
+      name
+    `,
+    applicationProtection: `
+      _id,
+      state,
+      bail,
+      deprecations {
+        type,
+        entity
+      },
+      errorMessage,
+      sources {
+        filename,
+        errorMessages {
+          message,
+          line,
+          column,
+          fatal
+        }
+      }
+    `
+  }
+};


### PR DESCRIPTION
…ion that is being used

Different version of the API have different schemas and this has to be handled properly. This is a
quick solution for now but will need more work in the near future.

This will also make sure that exit code is not `0` when protection fails.